### PR TITLE
v1.11 backports 2023-03-11

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1739,7 +1739,7 @@ func runDaemon() {
 	}
 
 	if !option.Config.DryMode {
-		if k8s.IsEnabled() {
+		if k8s.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup {
 			go func() {
 				if restoreComplete != nil {
 					<-restoreComplete


### PR DESCRIPTION
- [ ] #24132 -- bpf: Ignore HOST_ID resolved from ipcache for IPv6 case (@ysksuzuki)
 - [ ] #23874 -- Check stale cilium endpoint flag before cleaning endpoints (@sjdot)
 - [ ] #24171 -- Fix duplicated logs for test-output.log (@romanspb80)
 - [ ] #24164 -- Update clustermesh requirements to mention node InternalIP explicitly (@jspaleta)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 24132 23874 24171 24164; do contrib/backporting/set-labels.py $pr done 1.11; done
```