### PR TITLE
v1.12 backports 2023-03-11

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1737,7 +1737,7 @@ func runDaemon() {
 	}
 
 	if !option.Config.DryMode {
-		if k8s.IsEnabled() {
+		if k8s.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup {
 			go func() {
 				if restoreComplete != nil {
 					<-restoreComplete


### PR DESCRIPTION
- [ ] #23874 -- Check stale cilium endpoint flag before cleaning endpoints (@sjdot)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23874 ; do contrib/backporting/set-labels.py $pr done 1.12; done
```