### PR TITLE
v1.13 backports 2023-03-11

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1767,7 +1767,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 			<-restoreComplete
 		}
 
-		if params.Clientset.IsEnabled() {
+		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup {
 			// Use restored endpoints to delete local CiliumEndpoints which are not in the restored endpoint cache.
 			// This will clear out any CiliumEndpoints that may be stale.
 			// Likely causes for this are Pods having their init container restarted or the node being restarted.


### PR DESCRIPTION
- [ ] #23874 -- Check stale cilium endpoint flag before cleaning endpoints (@sjdot)

 Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23874 ; do contrib/backporting/set-labels.py $pr done 1.13; done
```